### PR TITLE
allow instructors to review assignments from list_submissions

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -162,6 +162,13 @@ class AssignmentsController < ApplicationController
   def list_submissions
     @assignment = Assignment.find(params[:id])
     @teams = Team.where(parent_id: params[:id])
+    @participant = AssignmentParticipant.where(user_id: current_user.id, parent_id: @assignment.id).first
+    # If the current user is not a participant in the assignment, they cannot review submissions.
+    if not @participant.nil?
+      @review_maps = ReviewResponseMap.where(reviewer_id: @participant.id, reviewed_object_id: @assignment.id)
+    else
+      @review_maps = []
+    end
   end
 
   def remove_assignment_from_course

--- a/app/controllers/response_controller.rb
+++ b/app/controllers/response_controller.rb
@@ -211,6 +211,8 @@ class ResponseController < ApplicationController
       redirect_to view_student_teams_path student_id: @map.reviewer.id
     when "instructor"
       redirect_to controller: 'grades', action: 'view', id: @map.response_map.assignment.id
+    when "instructor_review"
+      redirect_to controller: 'assignments', action: 'list_submissions', id: @map.response_map.assignment.id
     when "assignment_edit"
       redirect_to controller: 'assignments', action: 'edit', id: @map.response_map.assignment.id
     when "selfreview"

--- a/app/controllers/review_mapping_controller.rb
+++ b/app/controllers/review_mapping_controller.rb
@@ -78,6 +78,19 @@ class ReviewMappingController < ApplicationController
     redirect_to action: 'list_mappings', id: assignment.id, msg: msg
   end
 
+  def add_instructor_as_reviewer
+    assignment = Assignment.find(params[:id])
+    user = User.from_params(params)
+
+    regurl = url_for id: assignment.id,
+                     user_id: user.id,
+                     contributor_id: params[:contributor_id]
+    reviewer = get_reviewer(user, assignment, regurl)
+
+    map = ReviewResponseMap.create(reviewee_id: params[:contributor_id], reviewer_id: reviewer.id, reviewed_object_id: assignment.id)
+    redirect_to :controller => 'response', :action => 'new', :id => map.id, :contributor_id => params[:contributor_id], :return => "instructor_review"
+  end
+
   # 7/12/2015 -zhewei
   # This method is used for assign submissions to students for peer review.
   # This method is different from 'assignment_reviewer_automatically', which is in 'review_mapping_controller'

--- a/app/views/assignments/list_submissions.html.erb
+++ b/app/views/assignments/list_submissions.html.erb
@@ -50,8 +50,33 @@
           <% team_name_color = get_team_name_color_in_list_submission(team) %>
           <td><p style = <%="color:#{team_name_color}"%>><%= team.name %></p>
           <% unless participants.empty? %>
-            <%= link_to 'Assign Grade', { controller: 'grades', action: 'view_team', id: participants.first.id}, target: '_blank' %></td>
+              <!-- If no due dates for assignment, allow assigning grades. -->
+            <% if not @assignment.find_due_dates('submission').nil? %>
+              <!-- If due date has passed, Assign Grade. Otherwise, allow reviews. -->
+              <% if Time.now > @assignment.find_due_dates('submission').sort[-1].due_at or not @participant %>
+                <%= link_to 'Assign Grade', { controller: 'grades', action: 'view_team', id: participants.first.id}, target: '_blank' %>
+              <% else %>
+                <% review = @review_maps.select{|m| m.reviewee_id == team.id} %>
+                <!-- If a review has not yet been performed, allow review. Otherwise, allow view/edit actions. -->
+                <% if review.size == 0 %>
+                  <%= link_to 'Perform Review', {:controller => 'review_mapping', :action => 'add_instructor_as_reviewer', :id => @assignment.id, :contributor_id => team.id, :user_id => current_user.id} %>
+                <% else %>
+                  <% r =  Response.where(["map_id IN (?)", review.last.id]).first %>
+                  <% if r %>
+                    <!-- Reviews cannot be edited after being submitted. -->
+                    <% if r.is_submitted %>
+                      <%= link_to 'View Review', {:controller => 'response', :action => 'view', :id => r.id, :return => "instructor_review"} %>
+                    <% else %>
+                      <%= link_to 'Edit Review', {:controller => 'response', :action => 'edit', :id => r.id, :return => "instructor_review"} %>
+                    <% end %>
+                  <% end %>
+                <% end %>
+              <% end %>
+            <% else %>
+              <%= link_to 'Assign Grade', { controller: 'grades', action: 'view_team', id: participants.first.id}, target: '_blank' %>
+            <% end %>
           <% end %>
+          </td>
         <% end %>
 
         <!--Team member(s) / Participant name-->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -304,6 +304,7 @@ resources :institution, except: [:destroy] do
       get :add_reviewer
       post :add_reviewer
       post :add_self_reviewer
+      post :add_instructor_as_reviewer
       get :add_self_reviewer
       get :add_user_to_assignment
       get :auto_complete_for_user_name


### PR DESCRIPTION
Allow instructors to review students' work. The links are now visible from the list_submissions page. Instructors cannot review if they are not a participant in the assignment and can't review if the due date has passed. Only one submission is allowed, but instructors can save and edit reviews before submitting.